### PR TITLE
feat: Add Option+Backspace support for macOS word deletion

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,7 @@
       </div>
       <div id="header">
         <header>KeyZen MAB by Adam Gradzki - Version 4.1</header>
-        <p>Delete a whole word at once with Control + Backspace</p>
+        <p>Delete a whole word at once with Control + Backspace (Windows/Linux) or Option + Backspace (macOS)</p>
         <p>
           Data on the bottom visually represents expected ngram performance.
         </p>

--- a/keyzen.js
+++ b/keyzen.js
@@ -250,7 +250,8 @@ function keydownHandler(e) {
 
   // Check if the control key is pressed and the backspace key is pressed.
   // This checks if the user is trying to reset the typing statistics.
-  if (e.ctrlKey && e.key === "Backspace") {
+  // Support both Ctrl+Backspace (Windows/Linux) and Option/Alt+Backspace (macOS)
+  if ((e.ctrlKey || e.altKey) && e.key === "Backspace") {
     // Prevent the default behavior of the backspace key.
     // This prevents the browser from navigating back when the backspace key is pressed.
     e.preventDefault();


### PR DESCRIPTION
## Summary
- Added support for Option+Backspace shortcut on macOS for word deletion
- Previously only Ctrl+Backspace was supported, which is not the standard macOS shortcut
- Modified the keyboard handler to accept both Ctrl+Backspace (Windows/Linux) and Alt/Option+Backspace (macOS)

## Changes
- Updated `keydownHandler` in keyzen.js to check for both `e.ctrlKey` and `e.altKey` with Backspace
- Updated documentation in index.html to mention both platform-specific shortcuts

## How to test locally

### Step 1: Clone and run locally
```bash
git clone https://github.com/nszceta/keyzen-mab.git
cd keyzen-mab
git checkout feature/option-backspace-macos-support
python -m http.server
```

### Step 2: Open in browser
Navigate to `http://localhost:8000`

### Step 3: Test the functionality
1. Start typing in the main typing area
2. Type several characters (e.g., "hello world")
3. Press **Option + Backspace** (on Mac)
4. The entire word should be deleted and typing statistics reset
5. Verify this works the same as **Ctrl + Backspace** on Windows/Linux

### Expected behavior
- Both Option+Backspace and Ctrl+Backspace should delete the entire current word
- The typing statistics should reset (word index, keys hit, errors cleared)
- The UI should update to show a fresh word to type

@fl0werpowers Could you please test this on macOS and confirm if Option+Backspace now works as expected?